### PR TITLE
Performance fix and extensionmethod additions

### DIFF
--- a/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
+++ b/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
+++ b/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
+++ b/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
@@ -411,7 +411,7 @@ namespace Lithnet.ResourceManagement.Client
                 }
                 else
                 {
-                    // Add values not found in initial values
+                    // Add values not found in the initial values
                     foreach (object newValue in this.values.Except(this.initialValues, AttributeValue.ValueComparer))
                         tempValueChanges.Add(new AttributeValueChange(ModeType.Insert, newValue));
 

--- a/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
+++ b/src/Lithnet.ResourceManagement.Client/Schema/AttributeValue.cs
@@ -411,43 +411,13 @@ namespace Lithnet.ResourceManagement.Client
                 }
                 else
                 {
-                    foreach (object newValue in this.values)
-                    {
-                        bool found = false;
+                    // Add values not found in initial values
+                    foreach (object newValue in this.values.Except(this.initialValues, AttributeValue.ValueComparer))
+                        tempValueChanges.Add(new AttributeValueChange(ModeType.Insert, newValue));
 
-                        foreach (object initialValue in this.initialValues)
-                        {
-                            if (AttributeValue.ValueComparer.Equals(initialValue, newValue))
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-
-                        if (!found)
-                        {
-                            tempValueChanges.Add(new AttributeValueChange(ModeType.Insert, newValue));
-                        }
-                    }
-
-                    foreach (object initialValue in this.initialValues)
-                    {
-                        bool found = false;
-
-                        foreach (object newValue in this.values)
-                        {
-                            if (AttributeValue.ValueComparer.Equals(initialValue, newValue))
-                            {
-                                found = true;
-                                break;
-                            }
-                        }
-
-                        if (!found)
-                        {
-                            tempValueChanges.Add(new AttributeValueChange(ModeType.Remove, initialValue));
-                        }
-                    }
+                    // Remove values that shouldn't exist anymore
+                    foreach (object removedValue in this.initialValues.Except(this.values, AttributeValue.ValueComparer))
+                        tempValueChanges.Add(new AttributeValueChange(ModeType.Remove, removedValue));
                 }
             }
 

--- a/src/Lithnet.ResourceManagement.Client/Utilities/Extensions.cs
+++ b/src/Lithnet.ResourceManagement.Client/Utilities/Extensions.cs
@@ -38,7 +38,6 @@ namespace Lithnet.ResourceManagement.Client
             else
             {
                 return convertedDateTime.ToString(TypeConverter.FimServiceDateFormat);
-
             }
         }
 
@@ -65,7 +64,7 @@ namespace Lithnet.ResourceManagement.Client
         }
 
         /// <summary>
-        /// Removes a specific value from the specifed attribute
+        /// Removes a specific value from the specified attribute
         /// </summary>
         /// <param name="attributeName">Name of the attribute</param>
         /// <param name="value">The value to remove</param>
@@ -76,7 +75,7 @@ namespace Lithnet.ResourceManagement.Client
         }
 
         /// <summary>
-        /// Sets the value of the attribute, overwriting any existing values present on the object
+        /// Sets the value of the specified attribute, overwriting any existing values present on the object
         /// </summary>
         /// <param name="attributeName">Name of the attribute</param>
         /// <param name="value">The value to set</param>
@@ -85,6 +84,5 @@ namespace Lithnet.ResourceManagement.Client
             if (rObject != null)
                 rObject.Attributes[attributeName].SetValue(value);
         }
-
     }
 }

--- a/src/Lithnet.ResourceManagement.Client/Utilities/Extensions.cs
+++ b/src/Lithnet.ResourceManagement.Client/Utilities/Extensions.cs
@@ -41,5 +41,50 @@ namespace Lithnet.ResourceManagement.Client
 
             }
         }
+
+        /// <summary>
+        /// Add the specified value to the collection of values of a multivalued attribute, or sets the value of a single-valued attribute
+        /// </summary>
+        /// <param name="attributeName">Name of the attribute</param>
+        /// <param name="value">The value to add</param>
+        public static void AddValue(this ResourceObject rObject, string attributeName, object value)
+        {
+            if (rObject != null)
+                rObject.Attributes[attributeName].AddValue(value);
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether the specified value is present on the specified attribute
+        /// </summary>
+        /// <param name="attributeName">Name of the attribute</param>
+        /// <param name="value">The value to check</param>
+        /// <returns>Returns false if ResourceObject is null or true or false depending on if the value exists on the given attribute</returns>
+        public static bool HasValue(this ResourceObject rObject, string attributeName, object value)
+        {
+            return rObject != null ? rObject.Attributes[attributeName].HasValue(value) : false;
+        }
+
+        /// <summary>
+        /// Removes a specific value from the specifed attribute
+        /// </summary>
+        /// <param name="attributeName">Name of the attribute</param>
+        /// <param name="value">The value to remove</param>
+        public static void RemoveValue(this ResourceObject rObject, string attributeName, object value)
+        {
+            if (rObject != null)
+                rObject.Attributes[attributeName].RemoveValue(value);
+        }
+
+        /// <summary>
+        /// Sets the value of the attribute, overwriting any existing values present on the object
+        /// </summary>
+        /// <param name="attributeName">Name of the attribute</param>
+        /// <param name="value">The value to set</param>
+        public static void SetValue(this ResourceObject rObject, string attributeName, object value)
+        {
+            if (rObject != null)
+                rObject.Attributes[attributeName].SetValue(value);
+        }
+
     }
 }


### PR DESCRIPTION
**Performance boost for multivalue fields**
Instead of using double foreach loops, use Linq Except which is a lot faster. Especially when there are a lot of values in the multivalue field.